### PR TITLE
Fix Apple TV 4K crash

### DIFF
--- a/code/iphone/gles_glue.c
+++ b/code/iphone/gles_glue.c
@@ -218,6 +218,9 @@ void glEnd( void ) {
 
 void landscapeViewport( GLint x, GLint y, GLsizei width, GLsizei height ) {
 	y = 0;	// !@#
+	if (displaywidth > width) {
+		y = (displaywidth - width) / 2;
+	}
     /* JDS proper fix for landscape orientation */
 	glViewport( y, x, width, height );
 }

--- a/code/iphone/iphone_loop.c
+++ b/code/iphone/iphone_loop.c
@@ -679,8 +679,12 @@ void iphoneSet2D( void ) {
 	// note that GL thinks the iphone is always
 	// in portrait mode as far as the framebuffer
 	// is concerned.
+	int x = 0;
+	if (displaywidth > SCREENWIDTH) {
+		x = (displaywidth - SCREENWIDTH) / 2;
+	}
     /* JDS proper fix for landscape orientation */
-	glViewport( 0,0, displaywidth, displayheight );
+	glViewport( x,0, displaywidth, displayheight );
 	glMatrixMode( GL_MODELVIEW );
     glLoadIdentity();
 	glEnable( GL_TEXTURE_2D );

--- a/code/iphone/iphone_loop.c
+++ b/code/iphone/iphone_loop.c
@@ -221,11 +221,11 @@ void SetButtonPics( ibutton_t *button, const char *picBase, const char *title, i
 	button->scale = 1.0f;
 	button->title = title;
     
-    button->x = x * ((float)displaywidth) / 480.0f;
-    button->y = y * ((float)displayheight) / 320.0f;
+    button->x = x * ((float)SCREENWIDTH) / 480.0f;
+    button->y = y * ((float)SCREENHEIGHT) / 320.0f;
     
-    float xRatio = ((float)displaywidth) / 480.0f;
-    float yRatio = ((float)displayheight) / 320.0f;
+    float xRatio = ((float)SCREENWIDTH) / 480.0f;
+    float yRatio = ((float)SCREENHEIGHT) / 320.0f;
     
     float themin = MIN( xRatio, yRatio );
     
@@ -236,8 +236,8 @@ void SetButtonPics( ibutton_t *button, const char *picBase, const char *title, i
 void SetButtonPicsAndSizes( ibutton_t *button, const char *picBase, const char *title, int x, int y, int w, int h ) {	
 	SetButtonPics( button, picBase, title, x, y );
     
-    float xRatio = ((float)displaywidth) / 480.0f;
-    float yRatio = ((float)displayheight) / 320.0f;
+    float xRatio = ((float)SCREENWIDTH) / 480.0f;
+    float yRatio = ((float)SCREENHEIGHT) / 320.0f;
     
     float themin = MIN( xRatio, yRatio );
     
@@ -526,8 +526,8 @@ return fx - x;
 float iphoneCenterText( float x, float y, float scale, const char *str ) {
 	float l = StringFontWidth( str );
     
-    x *= ((float)displaywidth) / 480.0f;
-    y *= ((float)displayheight) / 320.0f;
+    x *= ((float)SCREENWIDTH) / 480.0f;
+    y *= ((float)SCREENHEIGHT) / 320.0f;
     
 	x -= l * scale * 0.5 * screenResolutionScale * 2;
     

--- a/code/iphone/prboomInterface.c
+++ b/code/iphone/prboomInterface.c
@@ -281,7 +281,7 @@ void I_InitGraphics(void)
 	char titlebuffer[2048];
 	static int    firsttime=1;
 
-	SCREENWIDTH = displaywidth;
+	SCREENWIDTH = displaywidth > MAX_SCREENWIDTH ? MAX_SCREENWIDTH : displaywidth;
 	SCREENHEIGHT = displayheight;
 	
 	if (firsttime)


### PR DESCRIPTION
This pull request fixes a crash on the Apple TV 4K due to the viewport width (3840px) exceeding the maximum width (3072px). The crash can be reproduced in the Simulator by setting these values manually [here](https://github.com/tomkidd/DOOM-iOS/blob/master/code/iphone/prboomInterface.c#L284), setting the height value in excess of the maximum only seems to cause visual issues.

The logic used to centre the viewport isn't that elegant but should work across all tvOS and iOS devices.