### PR TITLE
Fix button text alignment

### DIFF
--- a/code/iphone/iphone_loop.c
+++ b/code/iphone/iphone_loop.c
@@ -406,7 +406,7 @@ boolean HandleButton( ibutton_t *button ) {
 	
     if ( button->title ) {
         float    length = StringFontWidth( button->title ) * 0.75;
-        float    x = button->x + button->drawWidth/2 - length/2;
+        float    x = button->x + button->drawWidth/2 - length*2;
         // don't push the text off the edge of the screen
         if ( x < 0 ) {
             x = 0;


### PR DESCRIPTION
This pull request fixes the alignment of the icon labels on the death screen.

Before: 
![IMG_7270](https://user-images.githubusercontent.com/2276355/96374795-49af4080-1175-11eb-86fd-48e057fb8816.jpeg)

After:
![IMG_7269](https://user-images.githubusercontent.com/2276355/96374794-487e1380-1175-11eb-94fd-24e20b1449f2.jpeg)
