### PR TITLE
Fix home button use during gameplay on tvOS

### DIFF
--- a/code/iphone/GameController.mm
+++ b/code/iphone/GameController.mm
@@ -122,6 +122,7 @@ bool iphoneControllerIsAvailable() {
                 }
             }
             
+#if !TARGET_OS_TV
             setupPauseButtonHandler(controller);
             
             // Register for controller connected/disconnected notifications
@@ -140,6 +141,7 @@ bool iphoneControllerIsAvailable() {
             [ns addObserverForName:GCControllerDidDisconnectNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
                 controller = nil;
             }];
+#endif
         }
         initialized = true; // Only need to do this once
     }

--- a/code/iphone/MainMenuViewController.mm
+++ b/code/iphone/MainMenuViewController.mm
@@ -234,6 +234,7 @@ BOOL settingsMenuSelected = NO;
     [ gAppDelegate ShowGLView ];
     
     ResumeGame();
+    paused = false;
     
     Sound_StartLocalSound( "iphone/baborted_01.wav" );
  
@@ -596,6 +597,7 @@ BOOL settingsMenuSelected = NO;
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
     if (!context.previouslyFocusedView && [context.nextFocusedView isKindOfClass:[Banner_SubItem class]]) {
         [ gAppDelegate HideGLView ];
+        paused = true;
     }
 }
 

--- a/code/iphone/MainMenuViewController.mm
+++ b/code/iphone/MainMenuViewController.mm
@@ -593,6 +593,12 @@ BOOL settingsMenuSelected = NO;
     }
 }
 
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
+    if (!context.previouslyFocusedView && [context.nextFocusedView isKindOfClass:[Banner_SubItem class]]) {
+        [ gAppDelegate HideGLView ];
+    }
+}
+
 #endif
 
 @end

--- a/code/iphone/MissionMenuViewController.mm
+++ b/code/iphone/MissionMenuViewController.mm
@@ -464,6 +464,10 @@ static const char * const MissionNames[TOTAL_EPISODES][9] = {
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
     NSLog(@"%@", context.nextFocusedView);
     
+    if (!context.previouslyFocusedView) {
+        [ gAppDelegate HideGLView ];
+    }
+
     [super didUpdateFocusInContext:context withAnimationCoordinator:coordinator];
     
     if ([context.nextFocusedView isKindOfClass:[idLabelButton class]]) {

--- a/code/iphone/MissionMenuViewController.mm
+++ b/code/iphone/MissionMenuViewController.mm
@@ -466,6 +466,7 @@ static const char * const MissionNames[TOTAL_EPISODES][9] = {
     
     if (!context.previouslyFocusedView) {
         [ gAppDelegate HideGLView ];
+        paused = true;
     }
 
     [super didUpdateFocusInContext:context withAnimationCoordinator:coordinator];


### PR DESCRIPTION
This pull request fixes a problem where using the home button can leave the game in an unusable state.

The `HideGLView` method should be called when the GLView is not active, although this does not occur and attempts to show the GLView will now fail. A workaround for this is to hide the GLView when the home button is pressed when playing a new game (`MainMenuViewController.mm`) and also when resuming a game (`MissionMenuViewController.mm`). There is [code](https://github.com/dnicolson/DOOM-iOS/blob/3dd7b3da703003efa468c283ed4de474cea06231/code/iphone/iphone_glViewController.mm#L171) to perform this but it is not called when using the home button.

On iOS the `controllerPausedHandler` method handles the paused state, this is problematic on tvOS as resuming games requires using the menu button twice. It also resumes games in the background if the menu button is used navigating throughout the menu. A solution to this is to set the pause state when the GLView is hidden and when a game is resumed.