### PR TITLE
Fix buffer overflow in M_LoadDefaultsFile

### DIFF
--- a/code/prboom/m_misc.c
+++ b/code/prboom/m_misc.c
@@ -987,7 +987,7 @@ void M_LoadDefaults (void)
     while (!feof(f))
       {
       isstring = false;
-      if (fscanf (f, "%79s %[^\n]\n", def, strparm) == 2)
+      if (fscanf (f, "%79s %99[^\n]\n", def, strparm) == 2)
         {
 
         //jff 3/3/98 skip lines not starting with an alphanum


### PR DESCRIPTION
This pull request fixes a potential buffer overflow which allows arbitrary code execution. Copied from https://github.com/AXDOOMER/doom-vanille/commit/8a6d9a02fa991a91ff90ccdc73b5ceabaa6cb9ec.